### PR TITLE
refactor(core): modernize parser and CLI to functional flow

### DIFF
--- a/bin/anmetrigal.ml
+++ b/bin/anmetrigal.ml
@@ -27,91 +27,57 @@
    *
    *
 *)
-open Lib.Entrada;;
-open Lib.Utiles;;
+open Lib.Entrada
+open Lib.Utiles
 
-let argumentos=Sys.argv;;
+let print_usage_and_exit () =
+  prerr_string "\n Usage:\n\tanmetrigal <input_file> <output_file>\n";
+  exit 1
+;;
 
-let _=
-  (
-   if ((Array.length argumentos) != 3)
-   then
-     (
-      prerr_string("\n Usage:\n\tanmetrigal <input_file> <output_file>\n");
-      exit 1
-     )
-  );;
+let validate_input_file input_file =
+  if not (Sys.file_exists input_file) then (
+    prerr_string ("\n Error: No existe fichero de entrada: " ^ input_file ^ ".\n");
+    exit 2)
+;;
 
-let fentrada=argumentos.(1);;
-let _ =
-  (
-   if (not (Sys.file_exists(fentrada)))
-   then
-     (
-      prerr_string("\n Error: No existe fichero de entrada: "^fentrada^".\n");
-	exit 2
-     )
-  )
-      ;;
+let output_verse out_channel verse (num_silabas, _) =
+  output_string out_channel (verse ^ "  \t" ^ string_of_int num_silabas ^ "\n")
+;;
 
+let format_esquema esquema =
+  esquema
+  |> List.map (String.make 1)
+  |> String.concat " "
+;;
 
+let print_estrofa_result out_channel versos =
+  let num_rima_lista = trata_estrofa versos in
+  List.iter2 (output_verse out_channel) versos num_rima_lista;
+  output_string out_channel ("\nEstrofa de " ^ string_of_int (num_versos versos) ^ " versos.\n");
+  let nom, esq, rim = identifica_estrofa num_rima_lista in
+  output_string out_channel ("É un/unha " ^ nom ^ ".\n");
+  output_string out_channel ("Esquema:  " ^ format_esquema esq ^ "\n");
+  let rima = if rim = "CO" then "consoante" else "asoante" in
+  output_string out_channel ("Ten rima " ^ rima ^ ".\n");
+  output_string out_channel "=================================\n\n"
+;;
 
-let lista_estrofas=separa_estrofas (haz_lista fentrada);;
+let analyze_file input_file output_file =
+  let lista_estrofas = separa_estrofas (haz_lista input_file) in
+  let out_channel = open_out output_file in
+  List.iter (print_estrofa_result out_channel) lista_estrofas;
+  output_string out_channel "\n\n";
+  close_out out_channel;
+  print_string "\nFicheiro analizado con éxito.\n"
+;;
 
-
-let h_salida=open_out argumentos.(2);;
-
-let rec recorre_estrofa listapares listaversos=
-  match listapares with
-    []         -> ()
-  | (n,_)::l3  ->
-      let verso=List.hd listaversos
-      in
-      (
-       output_string h_salida (verso^"  \t"^(string_of_int n)^"\n");
-       recorre_estrofa l3 (List.tl listaversos)
-      )
-	;;
-
-let rec para_toda_estrofa l=
-  match l with
-    []      ->  ()
-  | est::l1 ->
-      let num_rima_lista=trata_estrofa est
-      in
-      (
-       recorre_estrofa num_rima_lista est;
-       let n=string_of_int (num_versos est)
-       in
-       output_string h_salida ("\nEstrofa de "^n^" versos.\n");
-       let (nom,esq,rim)=identifica_estrofa num_rima_lista
-       in
-       (
-	output_string h_salida ("É un/unha "^nom^".\n");
-	output_string h_salida ("Esquema:  ");
-	let rec imp_esq l5=
-	  match l5 with
-	    []    -> ""
-	  | a1::b -> ((String.make 1 a1)^" ")^imp_esq b
-	in
-	let p=imp_esq esq
-	in output_string h_salida (p^"\n");
-	let rima=if rim="CO" then "consoante" else "asoante"
-	in
-	output_string h_salida ("Ten rima "^rima^".\n");
-	output_string h_salida ("=================================\n\n");
-       );
-
-       para_toda_estrofa l1
-      )
-	;;
-
-
-
-let _=para_toda_estrofa lista_estrofas ;;
-let _=  output_string h_salida "\n\n";;
-let _=close_out h_salida;;
-let _=print_string("\nFicheiro analizado con éxito.\n");;
-let _=exit 0;;
+let () =
+  match Array.to_list Sys.argv with
+  | [_; input_file; output_file] ->
+      validate_input_file input_file;
+      analyze_file input_file output_file;
+      exit 0
+  | _ -> print_usage_and_exit ()
 
 (* ************************************************************************ *)

--- a/lib/cadenaISO.ml
+++ b/lib/cadenaISO.ml
@@ -66,51 +66,29 @@ class cadenaISO cadena=
 
     method longitud = String.length _cadena
 
+    method private next_char_at pos =
+      let t = String.sub _cadena pos 1 in
+      if t = "\129"
+      then (String.sub _cadena pos 2, 2)
+      else (t, 1)
+
     method get =
-      let t=String.sub _cadena _donde 1
-      in
-      if t="\129"
-      then (String.sub _cadena _donde 2)
-      else t
+      fst (self#next_char_at _donde)
 
     method get2 =
-      let (car,inc)=
-	let t=String.sub _cadena _donde 1
-	in
-	if t="\129"
-	then ( (String.sub _cadena _donde 2), 2 )
-	else ( t, 1 )
-      in
-      let car2=
-	let t=String.sub _cadena (_donde+inc) 1
-	in
-	if t="\129"
-	then  (String.sub _cadena (_donde+inc) 2)
-	else  t
-      in
-      car^car2
+      let car, inc = self#next_char_at _donde in
+      let car2, _ = self#next_char_at (_donde + inc) in
+      car ^ car2
 
     method avanza d=
       if (_donde+d)<self#longitud then _donde <- _donde+d else raise (Invalid_argument "Clase cadenaISO")
     method s =
-      let (car,inc)=
-	let t=String.sub _cadena _donde 1
-	in
-	if t="\129"
-	then ( (String.sub _cadena _donde 2), 2 )
-	else ( t, 1 )
-      in
+      let car, inc = self#next_char_at _donde in
       _donde <- _donde + inc;
       car
 
     method sinc=
-      let car=
-	let t=String.sub _cadena _donde 1
-	in
-	if t="\129"
-	then  (String.sub _cadena _donde 2)
-	else  t
-      in
+      let car, _ = self#next_char_at _donde in
       car
 
     method sub i f=String.sub _cadena i f

--- a/lib/entrada.ml
+++ b/lib/entrada.ml
@@ -29,36 +29,30 @@
    *
    *
 *)
-let fin nomfich=
+let fin nomfich =
   try
     open_in nomfich
   with
-    Sys_error (er) ->
-      (
-       prerr_endline ("ERROR: Al abrir "^nomfich^" "^er);
-       exit 1
-      );;
+  | Sys_error er ->
+      prerr_endline ("ERROR: Al abrir " ^ nomfich ^ " " ^ er);
+      exit 1
+;;
 
-let linea fich=
+let linea fich =
   try
-    input_line fich
+    Some (input_line fich)
   with
-    End_of_file -> "FINFICH";;
+  | End_of_file -> None
+;;
 
-let haz_lista st=
-  let f=fin st
+let haz_lista st =
+  let fichero = fin st in
+  let rec aux acc =
+    match linea fichero with
+    | Some line -> aux (line :: acc)
+    | None ->
+        close_in fichero;
+        List.rev acc
   in
-  let rec aux a=
-    (
-     let t=linea f
-     in
-     if (t="FINFICH")
-     then
-       (
-	close_in f;
-	[]
-       )
-     else t::(aux a)
-    )
-  in
-  aux 0;;
+  aux []
+;;

--- a/lib/utiles.ml
+++ b/lib/utiles.ml
@@ -115,25 +115,23 @@ let es_consonante cade =
    *
    *
 *)
-let rec quita_vacio l=
-  match l with
-    []    -> []
-  | a::l1 -> if a="" then quita_vacio l1 else a::(quita_vacio l1);;
+let quita_vacio l =
+  List.filter (fun line -> line <> "") l;;
 
-let separa_estrofas l=
-  let t=quita_vacio l
+let separa_estrofas l =
+  let add_line line = function
+    | [] -> [[line]]
+    | stanza :: rest -> (line :: stanza) :: rest
   in
-  let rec aux lista=
-    match lista with
-      []    -> [[]]
-    | a::l1 ->
-	let t2=aux l1
-	in
-	if (String.contains a '@')
-	then []::t2
-	else (a::(List.hd (t2)))::(List.tl t2)
-  in
-  aux t;;
+  List.fold_right
+    (fun line acc ->
+      if String.contains line '@' then
+        [] :: acc
+      else
+        add_line line acc)
+    (quita_vacio l)
+    [[]]
+;;
 
 
 let es_separador st=(List.mem st separadores);;
@@ -163,51 +161,48 @@ let pon_separadores cade =
    *
 *)
 
-let analiza cadena=
-  let _cadena=new cadenaISO (vuelta (String.lowercase_ascii cadena))
+let analiza cadena =
+  let cadena_iso = new cadenaISO (vuelta (String.lowercase_ascii cadena)) in
+  let rec consume_until_vowel () =
+    if es_vocal cadena_iso#get then
+      ()
+    else (
+      ignore cadena_iso#s;
+      consume_until_vowel ())
   in
-  let _dondeparo=ref 0
-  in
-  let _donde=ref 0
-  in
-  let r=ref false
-  in
-  let _silabas=ref []
-  in
-  while (not !r) do
-    try
-      while (not (es_vocal _cadena#get)) do
-	       ignore _cadena#s
-      done;
-      if  (es_hiato _cadena#get2 )
-      then
-	(ignore _cadena#s;())
+  let consume_current_syllable () =
+    consume_until_vowel ();
+    if es_hiato cadena_iso#get2 then
+      ignore cadena_iso#s
+    else (
+      if es_diptongo cadena_iso#get2 then (
+        ignore cadena_iso#s;
+        ignore cadena_iso#s)
       else
-	(
-	 if (es_diptongo _cadena#get2 )
-	 then (ignore _cadena#s; ignore _cadena#s)
-	 else ignore _cadena#s;
-	 if (es_grupo_valido _cadena#get2 )
-	 then (ignore _cadena#s; ignore _cadena#s;())
-	 else
-	   (ignore _cadena#s;())
-	);
-      _silabas := (!_silabas)@[ vuelta (_cadena#sub !_dondeparo ((_cadena#donde)-(!_dondeparo)))];
-      _dondeparo := _cadena#donde;
+        ignore cadena_iso#s;
+      if es_grupo_valido cadena_iso#get2 then (
+        ignore cadena_iso#s;
+        ignore cadena_iso#s)
+      else
+        ignore cadena_iso#s)
+  in
+  let rec collect_syllables where_stopped acc =
+    try
+      consume_current_syllable ();
+      let next_stop = cadena_iso#donde in
+      let syllable = vuelta (cadena_iso#sub where_stopped (next_stop - where_stopped)) in
+      collect_syllables next_stop (syllable :: acc)
     with
-      Invalid_argument (_) ->
-	(
-	 r := true;
-	 _silabas := (!_silabas)@[ vuelta (
-				   try
-				     _cadena#sub !_dondeparo ((_cadena#donde+1)-(!_dondeparo))
-				   with
-				     Invalid_argument (_) ->
-				       _cadena#sub !_dondeparo ((_cadena#donde)-(!_dondeparo))
-)]
-	)
-  done;
-  List.rev !_silabas;;
+    | Invalid_argument _ ->
+        let trailing_syllable =
+          try
+            cadena_iso#sub where_stopped ((cadena_iso#donde + 1) - where_stopped)
+          with
+          | Invalid_argument _ -> cadena_iso#sub where_stopped (cadena_iso#donde - where_stopped)
+        in
+        vuelta trailing_syllable :: acc
+  in
+  collect_syllables 0 [];;
 
 
 (* ********************************************************************** *)
@@ -387,6 +382,11 @@ let solo_vocales st=
 
 
 (* ********************************************************************** *)
+let rec todos_iguais lista =
+  match lista with
+  | [] | [_] -> true
+  | a :: (b :: _ as resto) -> (a = b) && todos_iguais resto;;
+
 let riman_en_asonante lista=
   (*
      * Funcion que devuelve true  si la lista de terminaciones de verso
@@ -397,13 +397,7 @@ let riman_en_asonante lista=
    in
   let sin_consonantes=List.map solo_vocales temp
   in
-  let rec aux _ k=
-    match k with
-      []          -> true
-    | a::b::resto -> (a=b) && (aux b resto)
-    | _::[]       ->true
-  in
-  aux "" sin_consonantes;;
+  todos_iguais sin_consonantes;;
 
 (* ********************************************************************** *)
 let riman_en_consonante lista=
@@ -414,13 +408,7 @@ let riman_en_consonante lista=
   *)
   let temp=List.map sin_tildes lista
    in
-  let rec aux _ k=
-    match k with
-      []          -> true
-    | a::b::resto -> (a=b) && (aux b resto)
-    | _::[]       ->true
-  in
-  aux "" temp;;
+  todos_iguais temp;;
 
 
 (* ********************************************************************** *)
@@ -461,23 +449,13 @@ let encaja est esq=
      *  coinciden en el arte (mayor o menor) de sus corresp. versos.
      *
   *)
-  let  verso_arte_mayor l j=
-    let (i,_)=(List.nth l j)
-    in (i>8)
-  in
-  let esq_arte_mayor (_,lista,_) i=
-    let a=(List.nth lista i)
-    in
-    (a=(Char.uppercase_ascii a))
-  in
-  let rec aux i=
-    let le=List.length est
-    in
-    if i<le
-    then ((verso_arte_mayor est i)=(esq_arte_mayor esq i))&&(aux (i+1))
-    else true
-  in
-  aux 0;;
+  let verso_arte_mayor (silabas, _) = silabas > 8 in
+  let esq_arte_mayor letra = letra = Char.uppercase_ascii letra in
+  let (_, esquema, _) = esq in
+  List.for_all2
+    (fun verso letra -> verso_arte_mayor verso = esq_arte_mayor letra)
+    est esquema
+;;
 
 
 (* ********************************************************************** *)


### PR DESCRIPTION
## Summary
- refactor core helpers in `utiles.ml` to reduce imperative state and use list/recursion-based composition
- modernize `entrada.ml` line reading by replacing sentinel-based end-of-file handling with option-based flow
- refactor CLI orchestration in `bin/anmetrigal.ml` into small pure helpers for argument validation, stanza formatting, and output generation
- simplify duplicated ISO character decoding logic in `cadenaISO.ml` with a shared private method

## Why
This keeps behavior stable while making the codebase easier to reason about, safer to evolve, and more aligned with modern OCaml functional style.

## Validation
- `dune build`
- `dune test`