### PR TITLE
fix(rhyme): distinguish open and closed galician vowels in assonance

### DIFF
--- a/lib/utiles.ml
+++ b/lib/utiles.ml
@@ -380,6 +380,33 @@ let solo_vocales st=
   qaux 0;;
 
 
+(* ********************************************************************** *)
+let normaliza_vocales_asonante st =
+  let ob = new cadenaISO st in
+  let rec aux () =
+    let car =
+      try
+        ob#s
+      with
+      | Invalid_argument _ -> ""
+    in
+    if car = "" then
+      ""
+    else
+      let normalizada =
+        if car = "\129\225" then "a"
+        else if car = "\129\237" then "i"
+        else if car = "\129\250" then "u"
+        else if car = "\129\233" then "E"
+        else if car = "\129\243" then "O"
+        else car
+      in
+      normalizada ^ aux ()
+  in
+  aux ()
+;;
+
+
 
 (* ********************************************************************** *)
 let rec todos_iguais lista =
@@ -393,10 +420,14 @@ let riman_en_asonante lista=
      * riman en asonante (s�lo vocales despu�s de s�laba t�nica).
      *
   *)
-  let temp=List.map sin_tildes lista
+  let sin_consonantes =
+    List.map
+      (fun terminacion ->
+        terminacion
+        |> solo_vocales
+        |> normaliza_vocales_asonante)
+      lista
    in
-  let sin_consonantes=List.map solo_vocales temp
-  in
   todos_iguais sin_consonantes;;
 
 (* ********************************************************************** *)

--- a/test/test_anmetrigal.ml
+++ b/test/test_anmetrigal.ml
@@ -30,11 +30,20 @@ let test_tras_acento () =
 let test_solo_vocales () =
   check string "keep vowels" "aioaa" (Lib.Utiles.solo_vocales "cancionada")
 
+let test_normaliza_vocales_asonante () =
+  check string "open e and o are distinct" "EOaeiu" (Lib.Utiles.normaliza_vocales_asonante "\129\233\129\243\129\225e\129\237\129\250")
+
 let test_riman_asonante_true () =
   check bool "same assonance" true (Lib.Utiles.riman_en_asonante ["casa"; "pata"])
 
 let test_riman_asonante_false () =
   check bool "different assonance" false (Lib.Utiles.riman_en_asonante ["casa"; "cielo"])
+
+let test_riman_asonante_open_closed_distinction () =
+  check bool
+    "open and closed galician vowels do not match"
+    false
+    (Lib.Utiles.riman_en_asonante ["f\129\233r"; "fer"])
 
 let test_riman_consonante_true () =
   check bool "same ending" true (Lib.Utiles.riman_en_consonante ["canto"; "canto"])
@@ -81,8 +90,10 @@ let () =
       test_case "analiza" `Quick test_analiza;
       test_case "tras_acento" `Quick test_tras_acento;
       test_case "solo_vocales" `Quick test_solo_vocales;
+      test_case "normaliza_vocales_asonante" `Quick test_normaliza_vocales_asonante;
       test_case "riman asonante true" `Quick test_riman_asonante_true;
       test_case "riman asonante false" `Quick test_riman_asonante_false;
+      test_case "riman asonante open/closed" `Quick test_riman_asonante_open_closed_distinction;
       test_case "riman consonante true" `Quick test_riman_consonante_true;
       test_case "riman consonante false" `Quick test_riman_consonante_false;
       test_case "trata_verso" `Quick test_trata_verso;


### PR DESCRIPTION
## Summary
- implement explicit normalization for assonant rhyme comparison to distinguish Galician open vowels (`é`, `ó`) from closed vowels (`e`, `o`)
- keep accented `á`, `í`, and `ú` normalized to plain vowels while preserving open vowel identity through dedicated markers
- add focused tests to verify open/closed vowel distinction and regression coverage for assonance behavior

## Linked issue
- Closes #1

## Validation
- `dune build`
- `dune test`